### PR TITLE
Linkable terminology

### DIFF
--- a/src/introduction/a-path-to-pos-zcash.md
+++ b/src/introduction/a-path-to-pos-zcash.md
@@ -24,7 +24,7 @@ We are refining the design of TFL with several design goals in mind:
 - We want minimal-to-no disruption for existing wallet use cases and UX. For example, nothing should change for the user flows for storing or transferring funds, the format of addresses, etc…
 - We want a security analysis of the proposed protocol to be as simple as possible _given_ existing security analyses of current Zcash.
 - We want to enable new use cases around PoS that allow mobile shielded wallet users to earn a return on delegated ZEC.
-- We want to enable trust-minimized bridges and other benefits by providing a protocol with assured finality (see [Terminology: Protocol Concepts](../terminology.md#protocol_concepts)). 
+- We want to enable trust-minimized bridges and other benefits by providing a protocol with [assured finality](../terminology.md#definition-assured-finality). 
 - We want to improve the _modularity_ of the consensus protocol, which has several loosely defined and related meanings, e.g.: it's possible to understand some consensus properties only given knowledge of a "component" of the protocol, and it's possible to implement consensus rules in modular code components with clean interfaces.
 
 We will be refining these goals and potentially adding more as we continue to develop this proposal.

--- a/src/introduction/trailing-finality-layer-in-a-nutshell.md
+++ b/src/introduction/trailing-finality-layer-in-a-nutshell.md
@@ -4,7 +4,7 @@ The hybrid PoW/PoS protocol proposed in this book is similar to today's Zcash NU
 
 **TODO**: Add graphic showing nodes connected to each other in the p2p protocol. Each node has two parts: PoW and TFL. Each part has a distinct connection to the neighbors of the same part, so node A's "PoW" connects to node B's "PoW", node A's "TFL" connects to node B's "TFL". Finally, we want some way to visualize that all of the PoW nodes and connections were "pre-existing" and that the TFL pieces are a "new layer".
 
-The Zcash Trailing Finality Layer refers to a new subprotocol of a new hybrid PoW/PoS protocol, which we refer to as *PoW+TFL*. This subprotocol introduces [assured finality](../terminology.md#definition-assured-finality) for the Zcash blockchain, ensuring that *final* blocks (and the transactions within them) may never be rolled back.
+The Zcash Trailing Finality Layer refers to a new subprotocol of a new hybrid PoW/PoS protocol, which we refer to as [PoW+TFL](../terminology.md#definition-pow-tfl). This subprotocol introduces [assured finality](../terminology.md#definition-assured-finality) for the Zcash blockchain, ensuring that *final* blocks (and the transactions within them) may never be rolled back.
 
 We use the term "layer" because we can understand this design as introducing a new layer to the Zcash network, making only minimal changes to the existing network and consensus protocol. This modular separation is present in the consensus rules, the network protocol, and the code architecture.
 

--- a/src/introduction/trailing-finality-layer-in-a-nutshell.md
+++ b/src/introduction/trailing-finality-layer-in-a-nutshell.md
@@ -4,7 +4,7 @@ The hybrid PoW/PoS protocol proposed in this book is similar to today's Zcash NU
 
 **TODO**: Add graphic showing nodes connected to each other in the p2p protocol. Each node has two parts: PoW and TFL. Each part has a distinct connection to the neighbors of the same part, so node A's "PoW" connects to node B's "PoW", node A's "TFL" connects to node B's "TFL". Finally, we want some way to visualize that all of the PoW nodes and connections were "pre-existing" and that the TFL pieces are a "new layer".
 
-The Zcash Trailing Finality Layer refers to a new subprotocol of a new hybrid PoW/PoS protocol, which we refer to as *PoW+TFL*. This subprotocol introduces *assured finality* (see [Terminology: Protocol Concepts](../terminology.md#protocol_concepts)) for the Zcash blockchain, ensuring that *final* blocks (and the transactions within them) may never be rolled back.
+The Zcash Trailing Finality Layer refers to a new subprotocol of a new hybrid PoW/PoS protocol, which we refer to as *PoW+TFL*. This subprotocol introduces [assured finality](../terminology.md#definition-assured-finality) for the Zcash blockchain, ensuring that *final* blocks (and the transactions within them) may never be rolled back.
 
 We use the term "layer" because we can understand this design as introducing a new layer to the Zcash network, making only minimal changes to the existing network and consensus protocol. This modular separation is present in the consensus rules, the network protocol, and the code architecture.
 

--- a/src/introduction/trailing-finality-layer-in-a-nutshell.md
+++ b/src/introduction/trailing-finality-layer-in-a-nutshell.md
@@ -1,6 +1,6 @@
 # Trailing Finality Layer in a Nutshell
 
-The hybrid PoW/PoS protocol proposed in this book is similar to today's Zcash NU5 protocol with the addition of a *Trailing Finality Layer*:
+The hybrid PoW/PoS protocol proposed in this book is similar to today's Zcash [NU5](../terminology.md#definition-nu5) protocol with the addition of a *Trailing Finality Layer*:
 
 **TODO**: Add graphic showing nodes connected to each other in the p2p protocol. Each node has two parts: PoW and TFL. Each part has a distinct connection to the neighbors of the same part, so node A's "PoW" connects to node B's "PoW", node A's "TFL" connects to node B's "TFL". Finally, we want some way to visualize that all of the PoW nodes and connections were "pre-existing" and that the TFL pieces are a "new layer".
 
@@ -54,11 +54,11 @@ We believe this presents a minimal change to consensus rules to enable PoS, and 
 
 ### Modular Design
 
-By conceptualizing the TFL as a distinct "layer" or subprotocol, the consensus rules can be described as the explicit interactions between two subprotocols, one similar to the existing Zcash protcol as of NU5, and the other as a finalizing PoS protocol.
+By conceptualizing the TFL as a distinct "layer" or subprotocol, the consensus rules can be described as the explicit interactions between two subprotocols, one similar to the existing Zcash protcol as of [NU5](../terminology.md#definition-nu5), and the other as a finalizing PoS protocol.
 
 This approach helps in reasoning about failure modes, and how global consensus properties are achieved by which subprotocols.
 
-Finally, since one subprotocol is very similar to the existing Zcash NU5 protocol, this lessens risk that the consensus properties within that subprotocol compromise current NU5 properties.
+Finally, since one subprotocol is very similar to the existing Zcash [NU5](../terminology.md#definition-nu5) protocol, this lessens risk that the consensus properties within that subprotocol compromise current [NU5](../terminology.md#definition-nu5) properties.
 
 ### Modular Implementation
 

--- a/src/overview.md
+++ b/src/overview.md
@@ -6,7 +6,7 @@ This layer enables blocks produced via PoW to become *final* which ensures they 
 
 This consensus layer uses a finalizing *Proof-of-Stake (PoS)* consensus protocol, and enables ZEC holders to earn protocol rewards for contributing to the security of the Zcash network. By integrating a PoS layer with the current PoW Zcash protocol, this design specifies a *hybrid consensus protocol*.
 
-The integration of the current PoW consensus with the TFL produces a new top-level consensus protocol referred to as *PoW+TFL*.
+The integration of the current PoW consensus with the TFL produces a new top-level consensus protocol referred to as [PoW+TFL](./terminology.md#definition-pow-tfl).
 
 In the following subchapters we introduce the [Design at a Glance](./overview/design-at-a-glance.md), then provide an overview of the major components of the design.
 

--- a/src/overview/design-at-a-glance.md
+++ b/src/overview/design-at-a-glance.md
@@ -1,12 +1,12 @@
 # Design at a Glance
 
-The PoW+TFL consenus protocol is logically an extension of the Zcash consensus rules to introduce *trailing finality*. This is achieved by compartmentalizing the top-level PoW+TFL protocol into two *subprotocols*, one embodying most of the current consensus logic of Zcash and the TFL. These subprotocols interace through a strictly defined message-passing system called the *Subprotocol Interface*. (Remember to refer to [Terminology](../terminology.md) to clarify terms.)
+The [PoW+TFL](../terminology.md#definition-pow-tfl) consenus protocol is logically an extension of the Zcash consensus rules to introduce *trailing finality*. This is achieved by compartmentalizing the top-level [PoW+TFL](../terminology.md#definition-pow-tfl) protocol into two *subprotocols*, one embodying most of the current consensus logic of Zcash and the TFL. These subprotocols interace through a strictly defined message-passing system called the *Subprotocol Interface*. (Remember to refer to [Terminology](../terminology.md) to clarify terms.)
 
 **TODO:** Add consensus subprotocol diagram.
 
 ## Subprotocols
 
-The PoW+TFL hybrid consensus consists of two interacting subprotocols:
+The [PoW+TFL](../terminology.md#definition-pow-tfl) hybrid consensus consists of two interacting subprotocols:
 
 1. *PoW Subprotocol*: this subprotocol is very similar to NU5 consensus. It is a design goal of the TFL design to minimize changes to this subprotocol. Note: the shorthand "PoW" is potentially misleading, because this subprotocol is also responsible for the bulk of all supply and transaction semantic consensus rules.
 2. *TFL Subprotocol*: this is a new subprotocol which provides trailing finality via a finalizing PoS protocol.
@@ -25,7 +25,7 @@ Analyzing this design focuses on four areas:
 
 Consensus is specified in terms of the sub-consensus of each of the two subprotocols, PoW & TFL, along with the interface between the two, and finally in terms of system-wide / integrated consensus rules.
 
-We also explicitly define design goals about which areas of consensus _must not_ be impacted by a transition from NU5 to PoW+TFL.
+We also explicitly define design goals about which areas of consensus _must not_ be impacted by a transition from NU5 to [PoW+TFL](../terminology.md#definition-pow-tfl).
 
 ### Trailing Finality
 
@@ -45,4 +45,4 @@ The PoS consensus area is where the bulk of complexity lies in terms of the inte
 
 # Footnotes
 
-[^new-mainnet-precursors]: If new consensus changes are deployed to Zcash mainnet prior to PoW+TFL design finalization, this design must be updated to refer to the new delta (e.g. by reanalyzing all changes against NU6 or NU7, etc…)
+[^new-mainnet-precursors]: If new consensus changes are deployed to Zcash mainnet prior to [PoW+TFL](../terminology.md#definition-pow-tfl) design finalization, this design must be updated to refer to the new delta (e.g. by reanalyzing all changes against NU6 or NU7, etc…)

--- a/src/overview/design-at-a-glance.md
+++ b/src/overview/design-at-a-glance.md
@@ -39,7 +39,7 @@ There are no other changes to PoW subprotocol consensus specific to trailing fin
 
 ### Proof-of-Stake
 
-In order to achieve consensus on finality, the TFL uses a PoS protocol which provides assured finality (see [Terminology: Protocol Concepts](../terminology.md#protocol_concepts)).
+In order to achieve consensus on finality, the TFL uses a PoS protocol which provides [assured finality](../terminology.md#definition-assured-finality).
 
 The PoS consensus area is where the bulk of complexity lies in terms of the interface between the PoW and PoS subprotocols because PoW, which is generally responsible for supply and transaction semantics. See [The Subprotocol Interface](#the-subprotocol-interface) below for more detail.
 

--- a/src/overview/design-at-a-glance.md
+++ b/src/overview/design-at-a-glance.md
@@ -8,7 +8,7 @@ The [PoW+TFL](../terminology.md#definition-pow-tfl) consenus protocol is logical
 
 The [PoW+TFL](../terminology.md#definition-pow-tfl) hybrid consensus consists of two interacting subprotocols:
 
-1. *PoW Subprotocol*: this subprotocol is very similar to NU5 consensus. It is a design goal of the TFL design to minimize changes to this subprotocol. Note: the shorthand "PoW" is potentially misleading, because this subprotocol is also responsible for the bulk of all supply and transaction semantic consensus rules.
+1. *PoW Subprotocol*: this subprotocol is very similar to [NU5](../terminology.md#definition-nu5) consensus. It is a design goal of the TFL design to minimize changes to this subprotocol. Note: the shorthand "PoW" is potentially misleading, because this subprotocol is also responsible for the bulk of all supply and transaction semantic consensus rules.
 2. *TFL Subprotocol*: this is a new subprotocol which provides trailing finality via a finalizing PoS protocol.
 
 Validators must operate both subprotocols in an integrated manner. These subprotocols follow the design layed out in [Ebb-and-Flow design](../references.md#ebb-and-flow-protocols).
@@ -25,7 +25,7 @@ Analyzing this design focuses on four areas:
 
 Consensus is specified in terms of the sub-consensus of each of the two subprotocols, PoW & TFL, along with the interface between the two, and finally in terms of system-wide / integrated consensus rules.
 
-We also explicitly define design goals about which areas of consensus _must not_ be impacted by a transition from NU5 to [PoW+TFL](../terminology.md#definition-pow-tfl).
+We also explicitly define design goals about which areas of consensus _must not_ be impacted by a transition from [NU5](../terminology.md#definition-nu5) to [PoW+TFL](../terminology.md#definition-pow-tfl).
 
 ### Trailing Finality
 

--- a/src/overview/design-goals.md
+++ b/src/overview/design-goals.md
@@ -9,8 +9,8 @@ We strive to start our protocol design process from user experience (UX) and use
 - All currently supported wallet user experience should continue to operate seamlessly without change during or after protocol transitions. This covers the use of addresses, payment flow, transfers, ZEC supply cap and issuance rate, backup/restore, and other features users currently rely on.
 - There must be no security or safety degradation due to wallet user behavior introduced by PoS transitions, assuming users follow their current behaviors unchanged and continue to use the same cognitive model of the impacts of their behaviors. This goal encompasses all of security and safety, including privacy and transparency or more explicit disclosures.
 - The protocol should enable users of shielded mobile wallets to delegate ZEC to PoS consensus providers and earn a return on that ZEC coming via ZEC issuance or fees. Doing this may expose users to a risk of loss of delegated ZEC (such as through “slashing fees”). The protocol must guarantee that PoS consensus providers have no discretionary control over such delegated funds (including that they cannot steal those funds).
-- For any hybrid PoW/PoS protocol (including the PoW+TFL protocol we’re proposing), the process and UX of mining remains unchanged except that the return on investment may be altered. This is true both of consensus level block miners (ie mining pools and solo miners) and mining pool participants.
-- The any hybrid PoW/PoS protocol (including PoW+TFL) block explorers will continue to function with the same UX through transitions in-so-far as displaying information about transactions, the mempool, and blocks.
+- For any hybrid PoW/PoS protocol (including the [PoW+TFL](../terminology.md#definition-pow-tfl) protocol we’re proposing), the process and UX of mining remains unchanged except that the return on investment may be altered. This is true both of consensus level block miners (ie mining pools and solo miners) and mining pool participants.
+- The any hybrid PoW/PoS protocol (including [PoW+TFL](../terminology.md#definition-pow-tfl)) block explorers will continue to function with the same UX through transitions in-so-far as displaying information about transactions, the mempool, and blocks.
 - Block explorers and other network metrics sites may require UX changes with respect to mining rewards and issuance calculations.
 - Network metrics sites may require UX changes with respect to the p2p protocol or other network-specific information.
 
@@ -19,14 +19,14 @@ We strive to start our protocol design process from user experience (UX) and use
 For a full PoS transition, ecosystem developers for products such as consensus nodes, wallets, mining services, chain analytics, and more will certainly need to update their code to support transitions. However, we carve out a few goals as an exception to this for this category of users:
 
 - Wallet developers should not be required to make any changes through protocol transitions as long as they rely solely on the lightwalletd protocol or a full node API (such as the zcashd RPC interface).
-- For any hybrid PoW/PoS protocol (including PoW+TFL), mining pools and miners should not be required to make any software or protocol changes as long as they rely on zcashd-compatible GetBlockTemplate. One exception to this is software that bakes in assumptions about the block reward schedule, rather than relying on GetBlockTemplate solely.
+- For any hybrid PoW/PoS protocol (including [PoW+TFL](../terminology.md#definition-pow-tfl)), mining pools and miners should not be required to make any software or protocol changes as long as they rely on zcashd-compatible GetBlockTemplate. One exception to this is software that bakes in assumptions about the block reward schedule, rather than relying on GetBlockTemplate solely.
 
 ## Safety, Security, and Privacy Goals
 
 Zcash has always had exemplary safety, security, and privacy, and we aim to continue that tradition:
 
-- For any hybrid PoW/PoS protocol (including PoW+TFL), the cost-of-attack for a 1-hour rollback should not be reduced, given a “reasonably rigorous” security argument.
-- For any hybrid PoW/PoS protocol (including PoW+TFL), the cost-of-attack to halt the chain should be larger than the 24 hour revenue of PoW mining rewards, given a “reasonably rigorous” security argument.
+- For any hybrid PoW/PoS protocol (including [PoW+TFL](../terminology.md#definition-pow-tfl)), the cost-of-attack for a 1-hour rollback should not be reduced, given a “reasonably rigorous” security argument.
+- For any hybrid PoW/PoS protocol (including [PoW+TFL](../terminology.md#definition-pow-tfl)), the cost-of-attack to halt the chain should be larger than the 24 hour revenue of PoW mining rewards, given a “reasonably rigorous” security argument.
 
 TODO: privacy, pure-PoS security goals.
 

--- a/src/terminology.md
+++ b/src/terminology.md
@@ -8,38 +8,55 @@ We group terms into related categories as follows:
 
 ## Protocol Concepts
 
-- <span id="definition-assured-finality"></span>*Assured Finality*: A protocol property that guarantees that final transactions cannot be reverted by that protocol. As with all protocol guarantees, a protocol assumes certain conditions must be met.
+<span id="definition-assured-finality"></span>**Assured Finality**: A protocol property that guarantees that final transactions cannot be reverted by that protocol. As with all protocol guarantees, a protocol assumes certain conditions must be met.
 
-  Importantly, it is not feasible for any protocol to prevent reversing final transactions "out of band" from the protocol, such as if a sufficiently large and motivated group of users forks the network to include a specific new validity rule reverting transactions. For this reason, we forego the term "absolute finality" sometimes used in consensus protocol technical discussions.
+Importantly, it is not feasible for any protocol to prevent reversing final transactions "out of band" from the protocol, such as if a sufficiently large and motivated group of users forks the network to include a specific new validity rule reverting transactions. For this reason, we forego the term "absolute finality" sometimes used in consensus protocol technical discussions.
 
 ## Protocol Components
 
-- *PoW+TFL*: the overall complete, integrated consensus protocol specified in this book.
-- *NU5*: the Zcash consensus protocol as of NU5.[^new-mainnet-precursors]
-- *PoW*: the PoW subprotocol within PoW+TFL. Note that this is a different consensus protocol from NU5 and encompasses more than narrow Nakamoto PoW consensus, including transaction semantics such as for shielded transfers.
-- *TFL*: the *Trailing Finality Layer* subprotocol within PoW+TFL.
+<span id="definition-pow-tfl"></span>**PoW+TFL**: the overall complete, integrated consensus protocol specified in this book.
+
+<span id="definition-nu5"></span>**NU5**: the Zcash consensus protocol as of NU5.[^new-mainnet-precursors]
+
+<span id="definition-pow"></span>**PoW**: the PoW subprotocol within PoW+TFL. Note that this is a different consensus protocol from NU5 and encompasses more than narrow Nakamoto PoW consensus, including transaction semantics such as for shielded transfers.
+
+<span id="definition-tfl"></span>**TFL**: the *Trailing Finality Layer* subprotocol within PoW+TFL.
 
 ## Infrastructure Roles
 
 These are roles of infrastructure components (not human users). Keep in mind a given product or service may fill multiple roles, for example a wallet application may provide *validator*, *wallet viewer*, and *wallet spender* roles to provide users with safe access to private funds.
 
-- *Validator*: a component which locally verifies the correctness of consensus. This includes verifying that the local view of chain history matches consensus requirements, encompassing block tip selection, block validity, and transaction validity.[^validator-distinction]
-- *Block Proposer*: a component which proposes a block of transactions to the network. If accepted by network consensus, this block extends the consensus state of the ledger.
-- *PoW Proposer*: a Block Proposer which uses PoW as the proposal mechanism. In NU5 and PoW+TFL, the only Block Proposers are PoW Proposers. In practice, PoW Proposers are typically mining pools, although a solo miner is also a PoW Proposer. We use this term to be more precise than the common term "miner" which can conflate this role with the following:
-- *PoW Hashrate Provider*: a component which contributes mining resources towards PoW block proposals. In practice, mining pools rely on a userbase of Hashrate Providers to scale their operation, and solo miners have this capacity "in-house".
-- *Block Finalizer*: a component which contributes to consensus progress on the *finality* of a block.
-- *Wallet Viewer*: a component which provides a view into the history of funds for particular addresses, given appropriate *viewing keys*. This history may include both transparent and private details.
-- *Wallet Spender*: a component that enables generating new transactions which transfer funds to recipients.
+
+<span id="definition-validator"></span>**Validator**: a component which locally verifies the correctness of consensus. This includes verifying that the local view of chain history matches consensus requirements, encompassing block tip selection, block validity, and transaction validity.[^validator-distinction]
+
+<span id="definition-block-proposer"></span>**Block Proposer**: a component which proposes a block of transactions to the network. If accepted by network consensus, this block extends the consensus state of the ledger.
+
+<span id="definition-pow-proposer"></span>**PoW Proposer**: a Block Proposer which uses PoW as the proposal mechanism. In NU5 and PoW+TFL, the only Block Proposers are PoW Proposers. In practice, PoW Proposers are typically mining pools, although a solo miner is also a PoW Proposer. We use this term to be more precise than the common term "miner" which can conflate this role with the following.
+
+<span id="definition-pow-hashrate-provider"></span>**PoW Hashrate Provider**: a component which contributes mining resources towards PoW block proposals. In practice, mining pools rely on a userbase of Hashrate Providers to scale their operation, and solo miners have this capacity "in-house".
+
+<span id="definition-block-finalizer"></span>**Block Finalizer**: a component which contributes to consensus progress on the *finality* of a block.
+
+<span id="definition-wallet-viewer"></span>**Wallet Viewer**: a component which provides a view into the history of funds for particular addresses, given appropriate *viewing keys*. This history may include both transparent and private details.
+
+<span id="definition-wallet-spender"></span>**Wallet Spender**: a component that enables generating new transactions which transfer funds to recipients.
 
 ## Blockchain State
 
-- *Transaction*: a modification of the ledger, issued (by definition) by a Wallet Spender. A transaction cannot become part of the consensus ledger unless all Validators would accept it as valid according to *Transaction Validity Rules*.
-- *Block*: **\[TODO\]**
-- *Block History*: **\[TODO\]** _(nodes can see multiple local histories and select one as canonical according to consensus)
-- *Pending Blocks*: **\[TODO\]**
-- *Pending Transactions*: **\[TODO\]**
-- *Final Blocks*: **\[TODO\]**
-- *Final Transactions*: **\[TODO\]**
+
+<span id="definition-transaction"></span>**Transaction**: a modification of the ledger, issued (by definition) by a Wallet Spender. A transaction cannot become part of the consensus ledger unless all Validators would accept it as valid according to *Transaction Validity Rules*.
+
+<span id="definition-block"></span>**Block**: **\[TODO\]**
+
+<span id="definition-block-history"></span>**Block History**: **\[TODO\]** _(nodes can see multiple local histories and select one as canonical according to consensus)
+
+<span id="definition-pending-blocks"></span>**Pending Blocks**: **\[TODO\]**
+
+<span id="definition-pending-transactions"></span>**Pending Transactions**: **\[TODO\]**
+
+<span id="definition-final-blocks"></span>**Final Blocks**: **\[TODO\]**
+
+<span id="definition-final-transactions"></span>**Final Transactions**: **\[TODO\]**
 
 # Footnotes
 

--- a/src/terminology.md
+++ b/src/terminology.md
@@ -16,9 +16,9 @@ Importantly, it is not feasible for any protocol to prevent reversing final tran
 
 <span id="definition-pow-tfl"></span>**PoW+TFL**: the overall complete, integrated consensus protocol specified in this book.
 
-<span id="definition-pow"></span>**PoW**: the PoW subprotocol within [PoW+TFL](./terminology.md#definition-pow-tfl). Note that this is a different consensus protocol from [NU5](#definition-nu5) and encompasses more than narrow Nakamoto PoW consensus, including transaction semantics such as for shielded transfers.
+<span id="definition-pow"></span>**PoW**: the PoW subprotocol within [PoW+TFL](#definition-pow-tfl). Note that this is a different consensus protocol from [NU5](#definition-nu5) and encompasses more than narrow Nakamoto PoW consensus, including transaction semantics such as for shielded transfers.
 
-<span id="definition-tfl"></span>**TFL**: the *Trailing Finality Layer* subprotocol within [PoW+TFL](./terminology.md#definition-pow-tfl).
+<span id="definition-tfl"></span>**TFL**: the *Trailing Finality Layer* subprotocol within [PoW+TFL](#definition-pow-tfl).
 
 <span id="definition-nu5"></span>**NU5**: the Zcash consensus protocol as of NU5.[^new-mainnet-precursors]
 
@@ -31,7 +31,7 @@ These are roles of infrastructure components (not human users). Keep in mind a g
 
 <span id="definition-block-proposer"></span>**Block Proposer**: a component which proposes a block of transactions to the network. If accepted by network consensus, this block extends the consensus state of the ledger.
 
-<span id="definition-pow-proposer"></span>**PoW Proposer**: a Block Proposer which uses PoW as the proposal mechanism. In [NU5](#definition-nu5) and [PoW+TFL](./terminology.md#definition-pow-tfl), the only Block Proposers are PoW Proposers. In practice, PoW Proposers are typically mining pools, although a solo miner is also a PoW Proposer. We use this term to be more precise than the common term "miner" which can conflate this role with the following.
+<span id="definition-pow-proposer"></span>**PoW Proposer**: a Block Proposer which uses PoW as the proposal mechanism. In [NU5](#definition-nu5) and [PoW+TFL](#definition-pow-tfl), the only Block Proposers are PoW Proposers. In practice, PoW Proposers are typically mining pools, although a solo miner is also a PoW Proposer. We use this term to be more precise than the common term "miner" which can conflate this role with the following.
 
 <span id="definition-pow-hashrate-provider"></span>**PoW Hashrate Provider**: a component which contributes mining resources towards PoW block proposals. In practice, mining pools rely on a userbase of Hashrate Providers to scale their operation, and solo miners have this capacity "in-house".
 
@@ -60,6 +60,6 @@ These are roles of infrastructure components (not human users). Keep in mind a g
 
 # Footnotes
 
-[^new-mainnet-precursors]: If new consensus changes are deployed to Zcash mainnet prior to [PoW+TFL](./terminology.md#definition-pow-tfl) design finalization, this design must be updated to refer to the new delta (e.g. by reanalyzing all changes against NU6 or NU7, etc…)
+[^new-mainnet-precursors]: If new consensus changes are deployed to Zcash mainnet prior to [PoW+TFL](#definition-pow-tfl) design finalization, this design must be updated to refer to the new delta (e.g. by reanalyzing all changes against NU6 or NU7, etc…)
 
 [^validator-distinction]: Our use of the term "validator" deviates from common industry usage. Our usage focuses on literally validating consensus state, and does not imply any participation in maintaining the network or extending the ledger. This is distinct from widespread usage of "validator" to include the role or responsibility of proposing new blocks or achieving network consensus on ledger updates.

--- a/src/terminology.md
+++ b/src/terminology.md
@@ -8,7 +8,7 @@ We group terms into related categories as follows:
 
 ## Protocol Concepts
 
-- *Assured Finality*: A protocol property that guarantees that final transactions cannot be reverted by that protocol. As with all protocol guarantees, a protocol assumes certain conditions must be met.
+- <span id="definition-assured-finality"></span>*Assured Finality*: A protocol property that guarantees that final transactions cannot be reverted by that protocol. As with all protocol guarantees, a protocol assumes certain conditions must be met.
 
   Importantly, it is not feasible for any protocol to prevent reversing final transactions "out of band" from the protocol, such as if a sufficiently large and motivated group of users forks the network to include a specific new validity rule reverting transactions. For this reason, we forego the term "absolute finality" sometimes used in consensus protocol technical discussions.
 

--- a/src/terminology.md
+++ b/src/terminology.md
@@ -16,7 +16,7 @@ Importantly, it is not feasible for any protocol to prevent reversing final tran
 
 <span id="definition-pow-tfl"></span>**PoW+TFL**: the overall complete, integrated consensus protocol specified in this book.
 
-<span id="definition-pow"></span>**PoW**: the PoW subprotocol within [PoW+TFL](./terminology.md#definition-pow-tfl). Note that this is a different consensus protocol from NU5 and encompasses more than narrow Nakamoto PoW consensus, including transaction semantics such as for shielded transfers.
+<span id="definition-pow"></span>**PoW**: the PoW subprotocol within [PoW+TFL](./terminology.md#definition-pow-tfl). Note that this is a different consensus protocol from [NU5](#definition-nu5) and encompasses more than narrow Nakamoto PoW consensus, including transaction semantics such as for shielded transfers.
 
 <span id="definition-tfl"></span>**TFL**: the *Trailing Finality Layer* subprotocol within [PoW+TFL](./terminology.md#definition-pow-tfl).
 
@@ -31,7 +31,7 @@ These are roles of infrastructure components (not human users). Keep in mind a g
 
 <span id="definition-block-proposer"></span>**Block Proposer**: a component which proposes a block of transactions to the network. If accepted by network consensus, this block extends the consensus state of the ledger.
 
-<span id="definition-pow-proposer"></span>**PoW Proposer**: a Block Proposer which uses PoW as the proposal mechanism. In NU5 and [PoW+TFL](./terminology.md#definition-pow-tfl), the only Block Proposers are PoW Proposers. In practice, PoW Proposers are typically mining pools, although a solo miner is also a PoW Proposer. We use this term to be more precise than the common term "miner" which can conflate this role with the following.
+<span id="definition-pow-proposer"></span>**PoW Proposer**: a Block Proposer which uses PoW as the proposal mechanism. In [NU5](#definition-nu5) and [PoW+TFL](./terminology.md#definition-pow-tfl), the only Block Proposers are PoW Proposers. In practice, PoW Proposers are typically mining pools, although a solo miner is also a PoW Proposer. We use this term to be more precise than the common term "miner" which can conflate this role with the following.
 
 <span id="definition-pow-hashrate-provider"></span>**PoW Hashrate Provider**: a component which contributes mining resources towards PoW block proposals. In practice, mining pools rely on a userbase of Hashrate Providers to scale their operation, and solo miners have this capacity "in-house".
 

--- a/src/terminology.md
+++ b/src/terminology.md
@@ -14,6 +14,8 @@ Importantly, it is not feasible for any protocol to prevent reversing final tran
 
 ## Protocol Components
 
+*TODO*: Replace these terms as we integrate the Crosslink design work.
+
 <span id="definition-pow-tfl"></span>**PoW+TFL**: the overall complete, integrated consensus protocol specified in this book.
 
 <span id="definition-pow"></span>**PoW**: the PoW subprotocol within [PoW+TFL](#definition-pow-tfl). Note that this is a different consensus protocol from [NU5](#definition-nu5) and encompasses more than narrow Nakamoto PoW consensus, including transaction semantics such as for shielded transfers.

--- a/src/terminology.md
+++ b/src/terminology.md
@@ -18,9 +18,9 @@ Importantly, it is not feasible for any protocol to prevent reversing final tran
 
 <span id="definition-nu5"></span>**NU5**: the Zcash consensus protocol as of NU5.[^new-mainnet-precursors]
 
-<span id="definition-pow"></span>**PoW**: the PoW subprotocol within PoW+TFL. Note that this is a different consensus protocol from NU5 and encompasses more than narrow Nakamoto PoW consensus, including transaction semantics such as for shielded transfers.
+<span id="definition-pow"></span>**PoW**: the PoW subprotocol within [PoW+TFL](./terminology.md#definition-pow-tfl). Note that this is a different consensus protocol from NU5 and encompasses more than narrow Nakamoto PoW consensus, including transaction semantics such as for shielded transfers.
 
-<span id="definition-tfl"></span>**TFL**: the *Trailing Finality Layer* subprotocol within PoW+TFL.
+<span id="definition-tfl"></span>**TFL**: the *Trailing Finality Layer* subprotocol within [PoW+TFL](./terminology.md#definition-pow-tfl).
 
 ## Infrastructure Roles
 
@@ -31,7 +31,7 @@ These are roles of infrastructure components (not human users). Keep in mind a g
 
 <span id="definition-block-proposer"></span>**Block Proposer**: a component which proposes a block of transactions to the network. If accepted by network consensus, this block extends the consensus state of the ledger.
 
-<span id="definition-pow-proposer"></span>**PoW Proposer**: a Block Proposer which uses PoW as the proposal mechanism. In NU5 and PoW+TFL, the only Block Proposers are PoW Proposers. In practice, PoW Proposers are typically mining pools, although a solo miner is also a PoW Proposer. We use this term to be more precise than the common term "miner" which can conflate this role with the following.
+<span id="definition-pow-proposer"></span>**PoW Proposer**: a Block Proposer which uses PoW as the proposal mechanism. In NU5 and [PoW+TFL](./terminology.md#definition-pow-tfl), the only Block Proposers are PoW Proposers. In practice, PoW Proposers are typically mining pools, although a solo miner is also a PoW Proposer. We use this term to be more precise than the common term "miner" which can conflate this role with the following.
 
 <span id="definition-pow-hashrate-provider"></span>**PoW Hashrate Provider**: a component which contributes mining resources towards PoW block proposals. In practice, mining pools rely on a userbase of Hashrate Providers to scale their operation, and solo miners have this capacity "in-house".
 
@@ -60,6 +60,6 @@ These are roles of infrastructure components (not human users). Keep in mind a g
 
 # Footnotes
 
-[^new-mainnet-precursors]: If new consensus changes are deployed to Zcash mainnet prior to PoW+TFL design finalization, this design must be updated to refer to the new delta (e.g. by reanalyzing all changes against NU6 or NU7, etc…)
+[^new-mainnet-precursors]: If new consensus changes are deployed to Zcash mainnet prior to [PoW+TFL](./terminology.md#definition-pow-tfl) design finalization, this design must be updated to refer to the new delta (e.g. by reanalyzing all changes against NU6 or NU7, etc…)
 
 [^validator-distinction]: Our use of the term "validator" deviates from common industry usage. Our usage focuses on literally validating consensus state, and does not imply any participation in maintaining the network or extending the ledger. This is distinct from widespread usage of "validator" to include the role or responsibility of proposing new blocks or achieving network consensus on ledger updates.

--- a/src/terminology.md
+++ b/src/terminology.md
@@ -16,11 +16,11 @@ Importantly, it is not feasible for any protocol to prevent reversing final tran
 
 <span id="definition-pow-tfl"></span>**PoW+TFL**: the overall complete, integrated consensus protocol specified in this book.
 
-<span id="definition-nu5"></span>**NU5**: the Zcash consensus protocol as of NU5.[^new-mainnet-precursors]
-
 <span id="definition-pow"></span>**PoW**: the PoW subprotocol within [PoW+TFL](./terminology.md#definition-pow-tfl). Note that this is a different consensus protocol from NU5 and encompasses more than narrow Nakamoto PoW consensus, including transaction semantics such as for shielded transfers.
 
 <span id="definition-tfl"></span>**TFL**: the *Trailing Finality Layer* subprotocol within [PoW+TFL](./terminology.md#definition-pow-tfl).
+
+<span id="definition-nu5"></span>**NU5**: the Zcash consensus protocol as of NU5.[^new-mainnet-precursors]
 
 ## Infrastructure Roles
 


### PR DESCRIPTION
This adds anchors for every terminology definition.

Then, for _some_ references, it updates them to links to the definition. However, I decided not to update many term references, because when we integrate Crosslink I expect many of those terms to shift.

Also, add a `TODO` item in the `Terminology: Protocol Components` section to update all of those terms during Crosslink integration.