### PR TITLE
Add repository-tracked `git-hooks`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ There are two github CI workflows:
 - `render-site.yaml`: triggers on `push` to `main` to render the site to https://electric-coin-company.github.io/tfl-book/
   - **Warning:** this workflow relies on full read/write access to the `gh-pages` branch. Don't mess with that branch unless you're very confident in the impacts.
 
+## `git-hooks`
+
+There is a directory `git-hooks` that we advocate all contributors use.
+
+Use this command to enable it:
+
+```
+git config --local core.hooksPath git-hooks
+```
+
 ## Prerequisites
 
 ### Rust prerequisites

--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -8,7 +8,7 @@ function main
 	log-run ./util/find-orphaned-files.sh
 }
 
-# Used to log which check is being executed, then executing it:
+# Used to log which check is being executed, then execute it:
 function log-run
 {
 	echo "$0: $1"

--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -efuo pipefail
+
+function main
+{
+	log-run reject-unstaged-changes
+	log-run require-render-success
+	log-run ./util/find-orphaned-files.sh
+}
+
+# Used to log which check is being executed, then executing it:
+function log-run
+{
+	echo "$0: $1"
+	eval "$@"
+}
+
+function reject-unstaged-changes
+{
+	if [ "$(unstaged-changes | wc -l)" -gt 0 ]
+	then
+		echo 'Refusing to commit unstaged changes:'
+		unstaged-changes
+		exit 1
+	fi
+}
+
+function unstaged-changes
+{
+	# Unstaged changes have a non-' ' char in the second column:
+	git status --porcelain | grep -Eve '^.  '
+}
+
+function require-render-success
+{
+	# BUG: This succeeds even if there are warnings. There is no `--deny-warnings` equivalent for `mdbook` AFAICT.
+	mdbook build
+}
+
+main "$@"
+
+source ./util/run-local-hook.sh

--- a/util/run-local-hook.sh
+++ b/util/run-local-hook.sh
@@ -3,7 +3,7 @@
 # Usage: at the end of a repository-managed hook, simply do "source ~/util/run-local-hook.sh" which will introspect to find the hook name, check if the user has a local hook with that name, and then will execute it.
 
 set -x
-hookname="$0"
+hookname="$(basename "$0")"
 local_hook=".git/hooks/$hookname"
 
 if [ -f "$local_hook" ]

--- a/util/run-local-hook.sh
+++ b/util/run-local-hook.sh
@@ -1,0 +1,13 @@
+# This is a bash library (to be `source`'d) which runs a user's local git hook after running the repository-managed hook.
+#
+# Usage: at the end of a repository-managed hook, simply do "source ~/util/run-local-hook.sh" which will introspect to find the hook name, check if the user has a local hook with that name, and then will execute it.
+
+set -x
+hookname="$0"
+local_hook=".git/hooks/$hookname"
+
+if [ -f "$local_hook" ]
+then
+  echo "Executing $local_hook"
+  exec "$local_hook"
+fi

--- a/util/run-local-hook.sh
+++ b/util/run-local-hook.sh
@@ -2,7 +2,6 @@
 #
 # Usage: at the end of a repository-managed hook, simply do "source ~/util/run-local-hook.sh" which will introspect to find the hook name, check if the user has a local hook with that name, and then will execute it.
 
-set -x
 hookname="$(basename "$0")"
 local_hook=".git/hooks/$hookname"
 


### PR DESCRIPTION
This includes:

- Installation instructions in `README.md`.
- A `pre-commit` hook that:
  - avoids unstaged changes (which would confuse the next check by testing something different than what will be committed)
  - checks that rendering succeeds
  - checks for orphaned files (ie `.md` files that aren't linked to in the `SUMMARY.md`)
- A hook utility to run user's local hooks if they are defined. For example, `./git-hooks/pre-commit` will run `.git/hooks/pre-commit` as a final step if the latter exists.