### PR TITLE
Add non-goals: "out-of-scope goals" and "anti-goals".

### DIFF
--- a/src/overview/design-goals.md
+++ b/src/overview/design-goals.md
@@ -57,6 +57,7 @@ While these desiderata may be common across the blockchain consensus design spac
 - Prioritizing minimal time-to-finality over other considerations (such as protocol simplicity, impact on existing use cases, or other goals above).
 - In-protocol liquid staking derivatives.
 - Maximizing the PoS staked-voter count ceiling. For example, [Tendermint BFT](https://github.com/tendermint/tendermint#research) has a relatively low ceiling of ~hundreds of staked voters, whereas Ethereum's [Gasper](https://ethereum.org/en/developers/docs/consensus-mechanisms/pos/gasper/) supports hundreds of thousands of staked voters.
+- Reducing energy usage. While this would presumably be a goal of a pure PoS transition, it likely cannot be achieved for hybrid PoW/PoS without loss of security.
 
 ## Anti-Goals
 

--- a/src/overview/design-goals.md
+++ b/src/overview/design-goals.md
@@ -48,9 +48,9 @@ We want to follow some conservative design heuristics to minimize risk and mista
 
 # Non-goals
 
-These are not goals of the TFL design, either to simplify the scope of the initial design (aka [Out of Scope Goals](#out-of-scope-goals)), or because we believe some potential goal _should not_ be supported (aka [Anti-goals](#anti-goals)).
+These are not goals of the TFL design, either to simplify the scope of the initial design (a.k.a. [Out-of-Scope Goals](#out-of-scope-goals)), or because we believe some potential goal _should not_ be supported (a.k.a. [Anti-goals](#anti-goals)).
 
-## Out of Scope Goals
+## Out-of-Scope Goals
 
 While these desiderata may be common across the blockchain consensus design space, they are not specific goals for the initial TFL design. Note that these may be goals for future protocol improvements.
 
@@ -60,7 +60,7 @@ While these desiderata may be common across the blockchain consensus design spac
 
 ## Anti-Goals
 
-Distinctly from [Out of Scope Goals](#out-of-scope-goals) we track "anti-goals" which are potential goals that we _explicitly reject_, which are potential goals we aim to _not_ support even in future protocol improvements.
+Distinctly from [Out-of-Scope Goals](#out-of-scope-goals) we track "anti-goals" which are potential goals that we _explicitly reject_, which are potential goals we aim to _not_ support even in future protocol improvements.
 
 We currently have no defined anti-goals.
 

--- a/src/overview/design-goals.md
+++ b/src/overview/design-goals.md
@@ -45,6 +45,25 @@ We want to follow some conservative design heuristics to minimize risk and mista
 - Rely as much as possible on design components with adequate theoretical underpinnings and security analyses.
 - Minimize changes or variations on the above: strive to only alter existing work when necessary for overall design goals. For example, Zcash's privacy or issuance constraints are likely less common among existing PoS designs.
 
+
+# Non-goals
+
+These are not goals of the TFL design, either to simplify the scope of the initial design (aka [Out of Scope Goals](#out-of-scope-goals)), or because we believe some potential goal _should not_ be supported (aka [Anti-goals](#anti-goals)).
+
+## Out of Scope Goals
+
+While these desiderata may be common across the blockchain consensus design space, they are not specific goals for the initial TFL design. Note that these may be goals for future protocol improvements.
+
+- Prioritizing minimal time-to-finality over other considerations (such as protocol simplicity, impact on existing use cases, or other goals above).
+- In-protocol liquid staking derivatives.
+- Maximizing the PoS staked-voter count ceiling. For example, [Tendermint BFT](https://github.com/tendermint/tendermint#research) has a relatively low ceiling of ~hundreds of staked voters, whereas Ethereum's [Gasper](https://ethereum.org/en/developers/docs/consensus-mechanisms/pos/gasper/) supports hundreds of thousands of staked voters.
+
+## Anti-Goals
+
+Distinctly from [Out of Scope Goals](#out-of-scope-goals) we track "anti-goals" which are potential goals that we _explicitly reject_, which are potential goals we aim to _not_ support even in future protocol improvements.
+
+We currently have no defined anti-goals.
+
 # Footnotes
 
 [^req-ttf-30m]: This requirement comes from [a request from a DEX developer](https://github.com/Electric-Coin-Company/tfl-book/issues/38). While we have not yet surveyed DEX and Bridge designs, we're relying on this as a good starting point.


### PR DESCRIPTION
**Note:** This extends #105 directly, and should be reviewed/merged after merging #105.

There are no currently defined "anti-goals", but I believe it's useful to have a placeholder section anyway to clarify our design approach.

This closes #23.