### PR TITLE
Remove "Minimal Consensus Changes" section; bolster "Modular Design" section.

### DIFF
--- a/src/introduction/a-path-to-pos-zcash.md
+++ b/src/introduction/a-path-to-pos-zcash.md
@@ -14,14 +14,16 @@ We envision a *proof-of-stake transition path* as one of the potential paths wit
 
 ## A Proof-of-Stake Transition Path
 
-Given that context, we envision a "path" within the Zcash Tech-Tree for transitioning Zcash to PoS. At the top level we propose that this path contain at least two major milestones:
+Given that context, we envision a path within the Zcash Tech-Tree for transitioning Zcash to PoS. At the top level we propose that this path contain at least two major milestones:
 
-1. Transitioning from current Zcash PoW to a hybrid PoW/PoS system.
-2. Transitioning from a hybrid PoW/PoS system to pure PoS.
+1. Transitioning from current Zcash [NU5](../terminology.md#definition-nu5) [PoW](../terminology.md#definition-pow) protocol to a PoW/PoS [hybrid consensus](../terminology.md#definition-hybrid-consensus) protocol dubbed [PoW+TFL](../terminology.md#definition-pow-tfl).
+2. Transitioning from [PoW+TFL](../terminology.md#definition-pow-tfl) to pure [PoS](../terminology.md#definition-pow-tfl) protocol.
 
 After this transition to pure PoS, there are likely to be future improvements to the PoS protocol, or the consensus protocol more generally. This TFL book focuses almost exclusively on the first step in this sequence.
 
 Our primary motivation for proposing (at least) two steps is to minimize disruption to usability, safety, security, and the ecosystem during each step.
+
+This book primarily focuses this first step: the transition to [PoW+TFL](../terminology.md#definition-pow-tfl). To understand the specific goals for that, see [Design Goals](../overview/design-goals.md). 
 
 With this approach, the Zcash Tech Tree with the [TFL](../terminology.md#definition-tfl) approach might look something like this:
 
@@ -29,20 +31,41 @@ With this approach, the Zcash Tech Tree with the [TFL](../terminology.md#definit
 {{#include ../diagrams/zcash-tech-tree-tfl-steps.dot}}
 ```
 
-## Design Goals for a Hybrid PoW/PoS System
+## Why Two Steps?
 
-We are refining the design of TFL with several design goals. As we refine the design and make various trade-offs, we may not be able to achieve all of these goals.
+One question we've gotten in proposing this approach is why take a two step process with an intermediate [hybrid consensus](../terminology.md#definition-hybrid-consensus) protocol, rather than a single transition directly to a [PoS](../terminology.md#definition-pos) protocol? 
 
-- We want minimal-to-no disruption for existing wallet use cases and UX. For example, nothing should change for the user flows for storing or transferring funds, the format of addresses, etc.
-- We want a security analysis of the proposed protocol to be as simple as possible given existing security analyses of current Zcash.
-- We want to enable new use cases around PoS that allow mobile shielded wallet users to earn a return on delegated ZEC.
-- We want to enable trust-minimized bridges and other benefits by providing a protocol with [assured finality](../terminology.md#definition-assured-finality).
-- We want to improve the _modularity_ of the consensus protocol. That is, it should be possible to understand some consensus properties only given knowledge of a "component" of the protocol, and it should be possible to implement consensus rules in modular code components with clean interfaces.
+Here's how we think about those trade-offs:
 
-We will be refining these goals and potentially adding more as we continue to develop this proposal.
+### Considering Single Transition (vs Hybrid Multi-Step)
 
-With the motivation and goals for a first-step hybrid PoW/PoS protocol in mind, we introduce the specifics of TFL in the next subchapter.
+#### Pros
+- We already understand the current PoW protocol well, and if we transition to an existing proven PoS protocol, then we could skip the complexity of an intermediate hybrid stage.
+- The node implementation might be simpler.
+- Explaining to people what is happening might be simpler. Something like “Zcash has been PoW since it launched, but on $DATE (e.g. at block height X) it will switch to PoS.”
+- Given that the issuance in a given time period is bounded by the supply curve, the full amount that was previously allocated to mining rewards becomes immediately available for staking rewards at the switch-over, rather than having to share this amount between mining and staking during the hybrid stage.
 
----
+#### Cons
+- If there is any unforeseen show-stopping problem in the new protocol or the transition process, we’d have to react to a network-wide issue.
+- It may be more likely to cause ecosystem disruption; unforeseen differences between PoW and PoS might cause various kinds of snags or papercuts throughout the ecosystem, and these would all pop up around the same time, which may lead to a loss of confidence/retention/adoption or at the very least inconvenience many users for some time.
+- Losing miners: since the transition would be all at once, we may lose some number of miners, who are participants and users in the ecosystem. Miners may leave prior to the transition in order to take care of their own needs. If there is some show-stopper in the transition, one possible short-term mitigation would be to fall back on PoW which is well-known, but if we’ve lost most miners, that may no longer be viable.
+
+### Considering Hybrid Multi-Step approach (vs Single-Step):
+
+Note: TFL is one instance of a multi-step approach.
+
+#### Pros
+- We can hopefully be less disruptive across the ecosystem so that there are fewer snags and disruptions with each step.
+- If there is a show-stopping flaw in any step, the fall-back possibility seems more plausible. For example, if there is a show-stopper when transitioning from PoW to [PoW+TFL](../terminology.md#definition-pow-tfl), falling back to pure PoW seems more feasible, since both protocols rely on mainnet PoW infrastructure, so those participants will be present in either case.
+- Retaining miners during a hybrid phase: while it is true that a hybrid protocol will lower miner revenue (since we aim to maintain the issuance schedule constraints), there is also more possibility and likelihood of keeping some of these users engaged. For example, they may begin participating in staking services (either as delegators or as infrastructure operators). If that is successful, then they’re also more likely to remain engaged in the subsequent transition to pure PoS.
+- This general approach was demonstrated successfully by Ethereum, which is the largest or second largest cryptocurrency network for several important metrics (e.g. market cap, fees paid, user and developer activity, …). So we know this can be done well without disruptions.
+
+#### Cons
+- The intermediate hybrid step will be a more novel and less well understood protocol. (It will necessarily be fairly different from Ethereum’s Beacon chain era.)
+- Consensus nodes will be more complex, involving logic for both sub-protocols as well as their integration. (Ideally this complexity can be modularized so that the nodes are easier to maintain and improve.)
+- This may be more complicated to explain to current and potential new users. Something like “Zcash launched as PoW, and on $DATE (block height X) it will transition to a hybrid system, then later to a pure PoS system.”
+- The available issuance must be shared between mining and staking rewards during the hybrid stage. The security of the PoW layer and of the PoS layer during this stage is partially dependent on the funds allocated to issuance for each protocol, and it is not yet clear to what extent splitting rewards would affect overall security.
+
+# Footnotes
 
 [^tech-tree-history]: See [Wikipedia's Technology Tree - History](https://en.wikipedia.org/wiki/Technology_tree#History) section for details.

--- a/src/introduction/trailing-finality-layer-in-a-nutshell.md
+++ b/src/introduction/trailing-finality-layer-in-a-nutshell.md
@@ -40,7 +40,7 @@ In a sense, we can think of this approach as enabling the Zcash community to "di
 
 ### Minimal Use-Case Disruption
 
-In many cases, existing products, services, and tools can continue using the mainnet chain with no changes to code assuming they rely on existingn consensus nodes. We view this as a major benefit which allows Zcash's existing user network effect to continue safely unperturbed.
+In many cases, existing products, services, and tools can continue using the mainnet chain with no changes to code assuming they rely on existing consensus nodes. We view this as a major benefit which allows Zcash's existing user network effect to continue safely unperturbed.
 
 There will be certain narrow exceptional areas if those products, services, or tools need to be precise in areas where the protocol has changed, such as mining/staking reward calculations, transaction formats (in particular any new PoS-related fields or logic), or chain rollback logic.
 

--- a/src/introduction/trailing-finality-layer-in-a-nutshell.md
+++ b/src/introduction/trailing-finality-layer-in-a-nutshell.md
@@ -44,21 +44,13 @@ In many cases, existing products, services, and tools can continue using the mai
 
 There will be certain narrow exceptional areas if those products, services, or tools need to be precise in areas where the protocol has changed, such as mining/staking reward calculations, transaction formats (in particular any new PoS-related fields or logic), or chain rollback logic.
 
-### Minimal Consensus Rule Changes
-
-Outside of PoS mechanics (such as bonding/unbonding stake, delegating, etc…), and changes to issuance (due to supporting both PoS and PoW) this design adds precisely one consensus rule:
-
-> Final blocks may not be rolled back.
-
-We believe this presents a minimal change to consensus rules to enable PoS, and is thus one of the safest approaches to a transition in terms of security analysis.
-
 ### Modular Design
 
-By conceptualizing the TFL as a distinct "layer" or subprotocol, the consensus rules can be described as the explicit interactions between two subprotocols, one similar to the existing Zcash protcol as of NU5, and the other as a finalizing PoS protocol.
+By conceptualizing the TFL as a distinct "layer" or subprotocol, the consensus rules can be described in terms of two [consensus subprotocols](../terminology.md#definition-consensus-subprotocols), one embodying most of the current consensus logic of Zcash and another the TFL. These protocols interact through a [hybrid construction](../terminology.md#definition-hybrid-construction). See [Design at a Glance](../overview/design-at-a-glance.md) to learn more about these distinct subprotocols.
 
-This approach helps in reasoning about failure modes, and how global consensus properties are achieved by which subprotocols.
+Reasoning about the whole protocol can leverage analysis and understanding of each subprotocol and the hybrid construction somewhat independently due to this modular design. Note that although this design is modular, the hybrid construction may require modifications to the [PoW] and/or [PoS] subprotocols to protect safety and liveness properties. Nevertheless, the modularity still improves analysis and reasoning compared to a monolithic design.
 
-Finally, since one subprotocol is very similar to the existing Zcash NU5 protocol, this lessens risk that the consensus properties within that subprotocol compromise current NU5 properties.
+Finally, since one subprotocol is very similar to the existing Zcash [NU5](../terminology.md#definition-nu5) protocol, this lessens risk that the consensus properties within that subprotocol compromise current NU5 properties.
 
 ### Modular Implementation
 

--- a/src/overview/design-goals.md
+++ b/src/overview/design-goals.md
@@ -19,6 +19,7 @@ We strive to start our protocol design process from user experience (UX) and use
 - The any hybrid PoW/PoS protocol (including PoW+TFL) block explorers will continue to function with the same UX through transitions in-so-far as displaying information about transactions, the mempool, and blocks.
 - Block explorers and other network metrics sites may require UX changes with respect to mining rewards and issuance calculations.
 - Network metrics sites may require UX changes with respect to the p2p protocol or other network-specific information.
+- Users can rely on [assured finality](../terminology.md#definition-assured-finality) with an expected time-to-finality of <30m.[^req-ttf-30m]
 
 ## Developer Experience Goals
 
@@ -43,3 +44,7 @@ We want to follow some conservative design heuristics to minimize risk and mista
 - Rely as much as possible on design components that are already proven in production environments.
 - Rely as much as possible on design components with adequate theoretical underpinnings and security analyses.
 - Minimize changes or variations on the above: strive to only alter existing work when necessary for overall design goals. For example, Zcash's privacy or issuance constraints are likely less common among existing PoS designs.
+
+# Footnotes
+
+[^req-ttf-30m]: This requirement comes from [a request from a DEX developer](https://github.com/Electric-Coin-Company/tfl-book/issues/38). While we have not yet surveyed DEX and Bridge designs, we're relying on this as a good starting point.

--- a/src/overview/design-goals.md
+++ b/src/overview/design-goals.md
@@ -45,6 +45,25 @@ We want to follow some conservative design heuristics to minimize risk and mista
 - Rely as much as possible on design components with adequate theoretical underpinnings and security analyses.
 - Minimize changes or variations on the above: strive to only alter existing work when necessary for overall design goals. For example, Zcash's privacy or issuance constraints are likely less common among existing PoS designs.
 
+
+# Non-goals
+
+These are not goals of the TFL design, either to simplify the scope of the initial design (aka [Out of Scope Goals](#out-of-scope-goals)), or because we believe some potential goal _should not_ be supported (aka [Anti-goals](#anti-goals)).
+
+## Out of Scope Goals
+
+While these desiderata may be common across the blockchain consensus design space, they are not specific goals for the initial TFL design. Note that these may be goals for future protocol improvements.
+
+- Prioritizing minimal time-to-finality over other considerations (such as protocol simplicity, impact on existing use cases, or other goals above).
+- In-protocol liquid staking derivatives.
+- Maximizing the PoS staked-voter count ceiling. For example, [Tendermint BFT](https://github.com/tendermint/tendermint#research) has a relatively low ceiling of ~hundreds of staked voters, whereas Ethereum's [Gasper](https://ethereum.org/en/developers/docs/consensus-mechanisms/pos/gasper/) supports hundreds of thousands of staked voters.
+
+## Anti-Goals
+
+Distinctly from [Out of Scope Goals](#out-of-scope-goals) we track "anti-goals" which are potential goals that we _explicitly reject_, which are potential goals we aim to _not_ support even in future protocol improvements.
+
+We currently have no defined anti-goals.
+
 # Footnotes
 
 [^req-ttf-30m]: This requirement comes from [a request from a DEX developer](https://github.com/Electric-Coin-Company/tfl-book/issues/38). While we have not yet surveyed DEX and Bridge designs, we're relying on this as a good starting point.


### PR DESCRIPTION
**Note:** This extends #107 directly which should be merged before this is reviewed/merged.

As I went to fix #93, I realized the "Minimal Consensus Changes" argument is weakened since Crosslink does not use PoW or PoS "off the shelf" and both need to be modified.[^1]

Furthermore, I realized the main benefit is modularity, rather than minimal changes, so I bolstered that section a bit and cross-referenced the "Design in a Nutshell" section which introduces the three major subprotocol components.

This fixes #93.

[^1]: The modification scope of subprotocols is restricted their objective validity rules, not fork choice, so there are still some constraints to those modification, and it would be good to document that. I'll add a separate ticket for this: #109