### PR TITLE
A nix flake for the final rendered result

### DIFF
--- a/.github/workflows/merge-acceptance.yaml
+++ b/.github/workflows/merge-acceptance.yaml
@@ -21,3 +21,12 @@ jobs:
     - run: mdbook build
     - name: Check for Orphaned Files
       run: ./util/find-orphaned-files.sh
+
+  # Reference: https://github.com/marketplace/actions/install-nix
+  check-flake:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v22
+    - run: nix build
+    - run: nix flake check

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ git config --local core.hooksPath git-hooks
 
 ## Prerequisites
 
-Note: nix users can rely on `flake.nix` which packages the final rendered html into `<prefix>/share/doc/tfl-book`. Users can install this via: `nix profile install 'github:Electric-Coin-Company/tfl-book'` or to build the local version `nix build`.
+Note: Nix users can rely on `flake.nix` which packages the final rendered HTML into `<prefix>/share/doc/tfl-book`. Users can install this via `nix profile install 'github:Electric-Coin-Company/tfl-book'`, or to build the local version `nix build`.
 
 ### Rust prerequisites
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ git config --local core.hooksPath git-hooks
 
 ## Prerequisites
 
+Note: nix users can rely on `flake.nix` which packages the final rendered html into `<prefix>/share/doc/tfl-book`. Users can install this via: `nix profile install 'github:Electric-Coin-Company/tfl-book'` or to build the local version `nix build`.
+
 ### Rust prerequisites
 
 - `cargo install mdbook`

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1701282334,
+        "narHash": "sha256-MxCVrXY6v4QmfTwIysjjaX0XUhqBbxTWWB4HXtDYsdk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "057f9aecfb71c4437d2b27d3323df7f93c010b7e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,38 @@
+{
+  description = "The Zcash Trailing Finality Layer Book";
+
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/23.11";
+
+  outputs = { self, nixpkgs }:
+  let
+    system = "x86_64-linux";
+    pkgs = nixpkgs.legacyPackages."${system}";
+
+    tfl-book-pkg = pkgs.stdenv.mkDerivation rec {
+      pname = "tfl-book";
+      version = "0.1.0"; # BUG: This should be derived from the `git describe --dirty`
+
+      buildInputs = with pkgs; [
+        mdbook
+        mdbook-graphviz
+        mdbook-linkcheck
+        strace
+      ];
+
+      src = ./.;
+
+      builder = pkgs.writeScript "${pname}-builder-${version}" ''
+        source "$stdenv/setup"
+        cp -a "$src" ./src
+        cd ./src
+        chmod -R u+w .
+        find "$(pwd)" -exec ls -ld '{}' \;
+        dest="$out/share/doc/${pname}/${version}"
+        mkdir -p "$dest"
+        strace mdbook build --dest-dir="$dest/"
+      '';
+    };
+  in {
+    packages."${system}".default = tfl-book-pkg;
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -26,10 +26,10 @@
         cp -a "$src" ./src
         cd ./src
         chmod -R u+w .
-        find "$(pwd)" -exec ls -ld '{}' \;
-        dest="$out/share/doc/${pname}/${version}"
-        mkdir -p "$dest"
-        mdbook build --dest-dir="$dest/"
+        mdbook build
+        dest="$out/share/doc/${pname}/"
+        mkdir -p "$(dirname "$dest")"
+        cp -a ./build/html "$dest"
       '';
     };
   in {

--- a/flake.nix
+++ b/flake.nix
@@ -13,10 +13,10 @@
       version = "0.1.0"; # BUG: This should be derived from the `git describe --dirty`
 
       buildInputs = with pkgs; [
+        graphviz
         mdbook
         mdbook-graphviz
         mdbook-linkcheck
-        strace
       ];
 
       src = ./.;
@@ -29,7 +29,7 @@
         find "$(pwd)" -exec ls -ld '{}' \;
         dest="$out/share/doc/${pname}/${version}"
         mkdir -p "$dest"
-        strace mdbook build --dest-dir="$dest/"
+        mdbook build --dest-dir="$dest/"
       '';
     };
   in {

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,7 @@
         mdbook
         mdbook-graphviz
         mdbook-linkcheck
+        mdbook-katex
       ];
 
       src = ./.;


### PR DESCRIPTION
This adds a nix flake (the modern nix packaging format) which produces the rendered html as the package.

This means any nix user can run `nix profile install 'github:Electric-Coin-Company/tfl-book' to install the rendered html locally.

This also adds CI which ensures the nix build and check processes complete without failure.